### PR TITLE
Add a character counter to the tweet msg in the Tweet to Download template

### DIFF
--- a/classes/class.enqueues.php
+++ b/classes/class.enqueues.php
@@ -136,6 +136,9 @@ class CTA_Enqueues {
 		wp_enqueue_script( 'wp-cta-admin-clear-stats-ajax-request', WP_CTA_URLPATH . 'js/ajax.clearstats.js', array( 'jquery' ) );
 		wp_localize_script( 'wp-cta-admin-clear-stats-ajax-request', 'ajaxadmin', array( 'ajaxurl' => admin_url('admin-ajax.php'), 'wp_call_to_action_clear_nonce' => wp_create_nonce('wp-call-to-action-clear-nonce') ) );
 
+		/* Add character counter to the text editor in the Tweet to download module */
+		wp_enqueue_script( 'jquery-character-counter', WP_CTA_URLPATH . 'js/libraries/jqEasyCharCounter/jquery.jqEasyCharCounter.js' );
+		
 		/*  Enqueue supporting js for Global Settings page */
 		if (isset($_GET['page']) && $_GET['page'] === 'wp_cta_global_settings') {
 			wp_enqueue_script('cta-settings-js', WP_CTA_URLPATH . 'js/admin/admin.global-settings.js');

--- a/js/libraries/jqEasyCharCounter/index.html
+++ b/js/libraries/jqEasyCharCounter/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<title>jQuery jqEasyCounter Plugin - Simple Character Counter</title>
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.2/jquery.min.js" type="text/javascript"></script>
+<script src="jquery.jqEasyCharCounter.min.js" type="text/javascript"></script>
+<script type="text/javascript">
+	$(document).ready(function(){
+		$('#countable1').jqEasyCounter();
+		
+		$('.countable2').jqEasyCounter({
+			'maxChars': 75,
+			'maxCharsWarning': 70
+		});
+		
+		$('#countable3').jqEasyCounter({
+			'maxChars': 50,
+			'maxCharsWarning': 40,
+			'msgFontSize': '12px',
+			'msgFontColor': '#000',
+			'msgFontFamily': 'Verdana',
+			'msgTextAlign': 'left',
+			'msgWarningColor': '#F00',
+			'msgAppendMethod': 'insertBefore'				
+		});
+
+		$('#testinput').jqEasyCounter({
+			'maxChars': 10,
+			'maxCharsWarning': 8
+		});
+});
+</script>
+</head>
+<body>
+    <h3>jqEasyCounter - Simple jQuery Character Counter Plugin</h3>
+    id="countable1"<br />
+    <textarea id="countable1" cols="30" rows="3"></textarea><br />
+    class="countable2"<br />
+    <textarea class="countable2" cols="30" rows="3"></textarea><br />
+    class="countable2"<br />
+    <textarea class="countable2" cols="30" rows="3"></textarea><br />
+    class="countable3"<br />
+    <textarea id="countable3" cols="30" rows="3"></textarea><br />
+    <br />
+    id="testinput"<br />
+    <input id="testinput" type="text">
+    <p><a href="http://www.jqeasy.com/jquery-character-counter/">&laquo; Back to article</a></p>
+</body>
+</html>

--- a/js/libraries/jqEasyCharCounter/jquery.jqEasyCharCounter.js
+++ b/js/libraries/jqEasyCharCounter/jquery.jqEasyCharCounter.js
@@ -1,0 +1,83 @@
+/* jQuery jqEasyCharCounter plugin
+ * Examples and documentation at: http://www.jqeasy.com/
+ * Version: 1.0 (05/07/2010)
+ * No license. Use it however you want. Just keep this notice included.
+ * Requires: jQuery v1.3+
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+jQuery(document).ready(function($) {
+
+$.fn.extend({
+    jqEasyCounter: function(givenOptions) {
+        return this.each(function() {
+            var $this = $(this),
+                options = $.extend({
+                    maxChars: 100,
+					maxCharsWarning: 80,
+					msgFontSize: '12px',
+					msgFontColor: '#000000',
+					msgFontFamily: 'Arial',
+					msgTextAlign: 'right',
+					msgWarningColor: '#F00',
+					msgAppendMethod: 'insertAfter'
+                }, givenOptions);
+	
+			if(options.maxChars <= 0) return;
+			
+			// create counter element
+			var jqEasyCounterMsg = $("<div class=\"jqEasyCounterMsg\">&nbsp;</div>");
+			var jqEasyCounterMsgStyle = {
+				'font-size' : options.msgFontSize,
+				'font-family' : options.msgFontFamily,
+				'color' : options.msgFontColor,
+				'text-align' : options.msgTextAlign,
+				'width' : $this.width(),
+				'opacity' : 0
+			};
+			jqEasyCounterMsg.css(jqEasyCounterMsgStyle);
+			// append counter element to DOM
+			jqEasyCounterMsg[options.msgAppendMethod]($this);
+			
+			// bind events to this element
+			$this
+				.bind('keydown keyup keypress', doCount)
+				.bind('focus paste', function(){setTimeout(doCount, 10);})
+				.bind('blur', function(){jqEasyCounterMsg.stop().fadeTo( 'fast', 0);return false;});
+			
+			function doCount(){
+				var val = $this.val(),
+					length = val.length
+				
+				if(length >= options.maxChars) {
+					val = val.substring(0, options.maxChars); 				
+				};
+				
+				if(length > options.maxChars){
+					// keep scroll bar position
+					var originalScrollTopPosition = $this.scrollTop();
+					$this.val(val.substring(0, options.maxChars));
+					$this.scrollTop(originalScrollTopPosition);
+				};
+				
+				if(length >= options.maxCharsWarning){
+					jqEasyCounterMsg.css({"color" : options.msgWarningColor});
+				}else {
+					jqEasyCounterMsg.css({"color" : options.msgFontColor});
+				};
+				
+				jqEasyCounterMsg.html('Characters: ' + $this.val().length + "/" + options.maxChars);
+                jqEasyCounterMsg.stop().fadeTo( 'fast', 1);
+			};
+        });
+    }
+});
+
+});

--- a/js/libraries/jqEasyCharCounter/jquery.jqEasyCharCounter.min.js
+++ b/js/libraries/jqEasyCharCounter/jquery.jqEasyCharCounter.min.js
@@ -1,0 +1,16 @@
+/* jQuery jqEasyCharCounter plugin
+ * Examples and documentation at: http://www.jqeasy.com/
+ * Version: 1.0 (05/07/2010)
+ * No license. Use it however you want. Just keep this notice included.
+ * Requires: jQuery v1.3+
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+ (function(a){a.fn.extend({jqEasyCounter:function(b){return this.each(function(){var f=a(this),e=a.extend({maxChars:100,maxCharsWarning:80,msgFontSize:"12px",msgFontColor:"#000000",msgFontFamily:"Arial",msgTextAlign:"right",msgWarningColor:"#F00",msgAppendMethod:"insertAfter"},b);if(e.maxChars<=0){return}var d=a('<div class="jqEasyCounterMsg">&nbsp;</div>');var c={"font-size":e.msgFontSize,"font-family":e.msgFontFamily,color:e.msgFontColor,"text-align":e.msgTextAlign,width:f.width(),opacity:0};d.css(c);d[e.msgAppendMethod](f);f.bind("keydown keyup keypress",g).bind("focus paste",function(){setTimeout(g,10)}).bind("blur",function(){d.stop().fadeTo("fast",0);return false});function g(){var i=f.val(),h=i.length;if(h>=e.maxChars){i=i.substring(0,e.maxChars)}if(h>e.maxChars){var j=f.scrollTop();f.val(i.substring(0,e.maxChars));f.scrollTop(j)}if(h>=e.maxCharsWarning){d.css({color:e.msgWarningColor})}else{d.css({color:e.msgFontColor})}d.html("Characters: "+f.val().length+"/"+e.maxChars);d.stop().fadeTo("fast",1)}})}})})(jQuery);

--- a/templates/tweet-to-download/config.php
+++ b/templates/tweet-to-download/config.php
@@ -118,3 +118,34 @@ array(
     );
 /* define dynamic template markup */
 $wp_cta_data[$key]['markup'] = file_get_contents($this_path . 'index.php');
+
+// add a character counter to the tweet to download module
+add_action( 'admin_print_footer_scripts','cta_tweettodownload_print_admin_scripts' );
+
+function cta_tweettodownload_print_admin_scripts() {
+    $screen = get_current_screen();
+
+        if ( !isset( $screen ) || $screen->id != 'wp-call-to-action' || $screen->parent_base != 'edit' ) {
+           return;
+        }
+
+        ?>
+        <script type="text/javascript">
+			jQuery(document).ready(function($) {
+				$('.share-text .wp-call-to-action-option-td textarea').addClass('tweet-to-download-share-text');
+				$('.tweet-to-download-share-text').jqEasyCounter({
+					maxChars: 120,                  // max number of characters
+					maxCharsWarning: 100,           // max number of characters before warning is shown
+					msgFontSize: '12px',            // css font size for counter
+					msgFontColor: '#000000',        // css font color for counter
+					msgFontFamily: 'Arial',         // css font family for counter
+					msgTextAlign: 'right',          // css text-align for counter (left, right, center)
+					msgWarningColor: '#FF0000',     // css font color for warning
+					msgAppendMethod: 'insertAfter'  // position of counter relative to the input element(insertAfter, insertBefore)
+				});
+			});
+        </script>
+
+        <?php
+
+}


### PR DESCRIPTION
This function add a character counter in the Tweet message editor so that people can know when they reach the 120 charachters allowed in their message.
To get to this, I decided to add a jQuery function to the library, enqueue it, and call this function from the config.php file that is loaded when the tweet to download template is used.